### PR TITLE
batch-submitter: min ether balance safety logging

### DIFF
--- a/src/batch-submitter/state-batch-submitter.ts
+++ b/src/batch-submitter/state-batch-submitter.ts
@@ -29,6 +29,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
     numConfirmations: number,
     finalityConfirmations: number,
     pullFromAddressManager: boolean,
+    minBalanceEther: number,
     log: Logger,
     fraudSubmissionAddress: string
   ) {
@@ -42,6 +43,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       numConfirmations,
       finalityConfirmations,
       pullFromAddressManager,
+      minBalanceEther,
       log
     )
     this.fraudSubmissionAddress = fraudSubmissionAddress

--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -51,6 +51,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     maxBatchSubmissionTime: number,
     numConfirmations: number,
     pullFromAddressManager: boolean,
+    minBalanceEther: number,
     log: Logger,
     disableQueueBatchAppend: boolean
   ) {
@@ -64,6 +65,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       numConfirmations,
       numConfirmations,
       pullFromAddressManager,
+      minBalanceEther,
       log
     )
     this.disableQueueBatchAppend = disableQueueBatchAppend

--- a/src/exec/run-batch-submitter.ts
+++ b/src/exec/run-batch-submitter.ts
@@ -45,6 +45,9 @@ interface RequiredEnvVars {
   RUN_TX_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_TX_BATCH_SUBMITTER'
   // Whether or not to run the state batch submitter.
   RUN_STATE_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_STATE_BATCH_SUBMITTER'
+  // The safe minimum amount of ether the batch submitter key should
+  // hold before it starts to log errors.
+  SAFE_MINIMUM_ETHER_BALANCE: 'SAFE_MINIMUM_ETHER_BALANCE'
 }
 const requiredEnvVars: RequiredEnvVars = {
   L1_NODE_WEB3_URL: 'L1_NODE_WEB3_URL',
@@ -58,6 +61,7 @@ const requiredEnvVars: RequiredEnvVars = {
   FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS',
   RUN_TX_BATCH_SUBMITTER: 'RUN_TX_BATCH_SUBMITTER',
   RUN_STATE_BATCH_SUBMITTER: 'RUN_STATE_BATCH_SUBMITTER',
+  SAFE_MINIMUM_ETHER_BALANCE: 'SAFE_MINIMUM_ETHER_BALANCE',
 }
 
 /* Optional Env Vars
@@ -116,6 +120,7 @@ export const run = async () => {
     parseInt(requiredEnvVars.MAX_BATCH_SUBMISSION_TIME, 10),
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     true,
+    parseFloat(requiredEnvVars.SAFE_MINIMUM_ETHER_BALANCE),
     getLogger(TX_BATCH_SUBMITTER_LOG_TAG),
     DISABLE_QUEUE_BATCH_APPEND
   )
@@ -130,6 +135,7 @@ export const run = async () => {
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     parseInt(requiredEnvVars.FINALITY_CONFIRMATIONS, 10),
     true,
+    parseFloat(requiredEnvVars.SAFE_MINIMUM_ETHER_BALANCE),
     getLogger(STATE_BATCH_SUBMITTER_LOG_TAG),
     FRAUD_SUBMISSION_ADDRESS
   )

--- a/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -153,6 +153,7 @@ describe('TransactionBatchSubmitter', () => {
         0,
         1,
         false,
+        1,
         getLogger(TX_BATCH_SUBMITTER_LOG_TAG),
         false
       )

--- a/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -253,6 +253,7 @@ describe('TransactionBatchSubmitter', () => {
         timeout,
         1,
         false,
+        1,
         getLogger(TX_BATCH_SUBMITTER_LOG_TAG),
         false
       )


### PR DESCRIPTION
This will log an error if the batch-submitter EOA balance is under a safe ether balance amount. This will enable alerting based on logs if the batch submitter is low on funds. This does add a new required environment variable for the batch-submitter `SAFE_MINIMUM_ETHER_BALANCE`