### PR TITLE
fixes: try/catch, log l2 queries on debug

### DIFF
--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -213,6 +213,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     this._updateLastL1BlockNumber() // TODO: Remove this
     const batch: Batch = []
     for (let i = startBlock; i < endBlock; i++) {
+      this.log.debug(`Fetching L2BatchElement ${i}`)
       batch.push(await this._getL2BatchElement(i))
     }
     let sequencerBatchParams = await this._getSequencerBatchParams(

--- a/src/exec/run-batch-submitter.ts
+++ b/src/exec/run-batch-submitter.ts
@@ -174,7 +174,7 @@ export const run = async () => {
         }
       }
     } catch (err) {
-      this.log.error('Cannot clear transactions', err)
+      log.error('Cannot clear transactions', err)
     }
 
     while (true) {

--- a/src/exec/run-batch-submitter.ts
+++ b/src/exec/run-batch-submitter.ts
@@ -121,7 +121,7 @@ export const run = async () => {
     parseInt(requiredEnvVars.MIN_TX_SIZE, 10),
     parseInt(requiredEnvVars.MAX_TX_SIZE, 10),
     parseInt(requiredEnvVars.MAX_BATCH_SIZE, 10),
-    parseInt(requiredEnvVars.MAX_BATCH_SUBMISSION_TIME, 10),
+    parseInt(requiredEnvVars.MAX_BATCH_SUBMISSION_TIME, 10) * 1_000,
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     parseInt(requiredEnvVars.RESUBMISSION_TIMEOUT, 10) * 1_000,
     true,


### PR DESCRIPTION
Adds a `try/catch` around the initial clear txs logic and also logs on `debug` for when its fetching L2 batch elements. This was really useful for debugging purposes