### PR TITLE
feat: decode sequencer batch

### DIFF
--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -157,14 +157,13 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   }
 
   public async _getBatchStartAndEnd(): Promise<Range> {
-    // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
     const startBlock =
       (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET
     const endBlock =
       Math.min(
         startBlock + this.maxBatchSize,
         await this.l2Provider.getBlockNumber()
-      ) + 1 // +1 because the `endBlock` is *exclusive*
+      )
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
         this.log
@@ -315,7 +314,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     }
 
     return {
-      // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
       shouldStartAtBatch: shouldStartAtIndex - BLOCK_OFFSET,
       totalElementsToAppend,
       contexts,

--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -163,7 +163,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       Math.min(
         startBlock + this.maxBatchSize,
         await this.l2Provider.getBlockNumber()
-      ) + 1 // +1 because the `endBlock` is *exclusive*
+      ) + 1 // +1 because the endBlock is *exclusive*
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
         this.log

--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -159,13 +159,11 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock =
       (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET
-    // TODO: the +1 introduces a bug where the batch size will
-    // be one larger than expected but removing it causes CI to fail
     const endBlock =
       Math.min(
         startBlock + this.maxBatchSize,
         await this.l2Provider.getBlockNumber()
-      ) + 1
+      ) + 1 // +1 because the `endBlock` is *exclusive*
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
         this.log

--- a/src/transaciton-chain-contract.ts
+++ b/src/transaciton-chain-contract.ts
@@ -2,7 +2,7 @@
 import { Contract, BigNumber } from 'ethers'
 import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { keccak256 } from 'ethers/lib/utils'
-import { remove0x, encodeHex } from './utils'
+import { add0x, remove0x, encodeHex } from './utils'
 
 export interface BatchContext {
   numSequencedTransactions: number
@@ -120,7 +120,7 @@ export const decodeAppendSequencerBatch = (b: string): AppendSequencerBatchParam
       const size = b.slice(offset, offset + 6)
       offset += 6
       const raw = b.slice(offset, offset + (parseInt(size, 16) * 2))
-      transactions.push(raw)
+      transactions.push(add0x(raw))
       offset += raw.length
     }
   }

--- a/src/transaciton-chain-contract.ts
+++ b/src/transaciton-chain-contract.ts
@@ -92,8 +92,6 @@ export const decodeAppendSequencerBatch = (b: string): AppendSequencerBatchParam
 
   const shouldStartAtBatch = b.slice(0, 10)
   const totalElementsToAppend = b.slice(10, 16)
-
-  //const contextHeader = b.slice(16, 22)
   const contextHeader = b.slice(16, 22)
   const contextCount = parseInt(contextHeader, 16)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,13 @@ export const toVerifiedBytes = (val: string, len: number) => {
 export const remove0x = (str: string): string => {
   if (str.startsWith('0x')) {
     return str.slice(2)
-  } else {
-    return str
   }
+  return str
+}
+
+export const add0x = (str: string): string => {
+  if (!str.startsWith('0x')) {
+    return `0x${str}`
+  }
+  return str
 }

--- a/test/batch-submitter/batch-encoder.spec.ts
+++ b/test/batch-submitter/batch-encoder.spec.ts
@@ -1,7 +1,7 @@
 import '../setup'
 
 /* Internal Imports */
-import { ctcCoder } from '../../src'
+import { ctcCoder, encodeAppendSequencerBatch, decodeAppendSequencerBatch } from '../../src'
 import { expect } from 'chai'
 
 describe('BatchEncoder', () => {
@@ -38,6 +38,37 @@ describe('BatchEncoder', () => {
       const encoded = ctcCoder.createEOATxData.encode(createEOATxData)
       const decoded = ctcCoder.createEOATxData.decode(encoded)
       expect(createEOATxData).to.deep.equal(decoded)
+    })
+  })
+
+  describe('appendSequencerBatch', () => {
+    it('should work with the simple case', () => {
+      const batch = {
+        shouldStartAtBatch: 0,
+        totalElementsToAppend: 0,
+        contexts: [],
+        transactions: [],
+      }
+      const encoded = encodeAppendSequencerBatch(batch)
+      const decoded = decodeAppendSequencerBatch(encoded)
+      expect(decoded).to.deep.equal(batch)
+    })
+
+    it('should work with more complex case', () => {
+      const batch = {
+        shouldStartAtBatch: 10,
+        totalElementsToAppend: 1,
+        contexts: [{
+          numSequencedTransactions: 2,
+          numSubsequentQueueTransactions: 1,
+          timestamp: 100,
+          blockNumber: 200
+        }],
+        transactions: ['45423400000011', '45423400000012'],
+      }
+      const encoded = encodeAppendSequencerBatch(batch)
+      const decoded = decodeAppendSequencerBatch(encoded)
+      expect(decoded).to.deep.equal(batch)
     })
   })
 })

--- a/test/batch-submitter/batch-encoder.spec.ts
+++ b/test/batch-submitter/batch-encoder.spec.ts
@@ -64,7 +64,7 @@ describe('BatchEncoder', () => {
           timestamp: 100,
           blockNumber: 200
         }],
-        transactions: ['45423400000011', '45423400000012'],
+        transactions: ['0x45423400000011', '0x45423400000012'],
       }
       const encoded = encodeAppendSequencerBatch(batch)
       const decoded = decodeAppendSequencerBatch(encoded)

--- a/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -183,12 +183,12 @@ describe('TransactionBatchSubmitter', () => {
       let logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(0) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(5) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(6) // _totalElements
       receipt = await batchSubmitter.submitNextBatch()
       logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(0) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
     })
 
     it('should submit a queue batch correctly', async () => {
@@ -199,13 +199,13 @@ describe('TransactionBatchSubmitter', () => {
       let receipt = await batchSubmitter.submitNextBatch()
       let logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
-      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(5) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(5) // _totalElements
+      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(6) // _numQueueElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(6) // _totalElements
       receipt = await batchSubmitter.submitNextBatch()
       logData = remove0x(receipt.logs[1].data)
-      expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(5) // _startingQueueIndex
+      expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(6) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(5) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
     })
 
     it('should submit a batch with both queue and sequencer chain elements', async () => {
@@ -237,8 +237,8 @@ describe('TransactionBatchSubmitter', () => {
       const receipt = await batchSubmitter.submitNextBatch()
       const logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
-      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(7) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
+      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(8) // _numQueueElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
     })
 
     it('should submit a small batch only after the timeout', async () => {

--- a/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -183,12 +183,12 @@ describe('TransactionBatchSubmitter', () => {
       let logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(0) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(6) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(5) // _totalElements
       receipt = await batchSubmitter.submitNextBatch()
       logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(0) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
     })
 
     it('should submit a queue batch correctly', async () => {
@@ -199,13 +199,13 @@ describe('TransactionBatchSubmitter', () => {
       let receipt = await batchSubmitter.submitNextBatch()
       let logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
-      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(6) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(6) // _totalElements
+      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(5) // _numQueueElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(5) // _totalElements
       receipt = await batchSubmitter.submitNextBatch()
       logData = remove0x(receipt.logs[1].data)
-      expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(6) // _startingQueueIndex
+      expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(5) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(5) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
     })
 
     it('should submit a batch with both queue and sequencer chain elements', async () => {
@@ -237,8 +237,8 @@ describe('TransactionBatchSubmitter', () => {
       const receipt = await batchSubmitter.submitNextBatch()
       const logData = remove0x(receipt.logs[1].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
-      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(8) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
+      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(7) // _numQueueElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
     })
 
     it('should submit a small batch only after the timeout', async () => {


### PR DESCRIPTION
There was an off by one error for the batch submitter where it would submit an extra element in each batch. The fix was to remove a `+ 1` that came with a comment regarding add one because it was exclusive. Maybe previously it was exclusive? I observe the correct behavior with this path, the `MAX_BATCH_SIZE` will result in the correct value instead of it being greater by one. This also adds a `decodeSequencerBatchAppend` function that is useful for decoding calldata.

The tests had to be updated due to the off by one error