### PR TITLE
Fix three terribly named variables

### DIFF
--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -16,7 +16,7 @@ import {
   CanonicalTransactionChainContract,
   encodeAppendSequencerBatch,
   BatchContext,
-  AppendSequencerBatchParams,
+  SequencerTransactionBatch,
 } from '../transaciton-chain-contract'
 import {
   EIP155TxData,
@@ -206,7 +206,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   private async _generateSequencerBatchParams(
     startBlock: number,
     endBlock: number
-  ): Promise<[AppendSequencerBatchParams, boolean]> {
+  ): Promise<[SequencerTransactionBatch, boolean]> {
     // Get all L2 BatchElements for the given range
     // For now we need to update our internal `lastL1BlockNumber` value
     // which is used when submitting batches.
@@ -240,7 +240,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   private async _getSequencerBatchParams(
     shouldStartAtIndex: number,
     blocks: Batch
-  ): Promise<AppendSequencerBatchParams> {
+  ): Promise<SequencerTransactionBatch> {
     const totalElementsToAppend = blocks.length
 
     // Generate contexts
@@ -316,7 +316,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
     return {
       // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
-      shouldStartAtBatch: shouldStartAtIndex - BLOCK_OFFSET,
+      shouldStartAtElement: shouldStartAtIndex - BLOCK_OFFSET,
       totalElementsToAppend,
       contexts,
       transactions,

--- a/src/transaciton-chain-contract.ts
+++ b/src/transaciton-chain-contract.ts
@@ -11,8 +11,8 @@ export interface BatchContext {
   blockNumber: number
 }
 
-export interface AppendSequencerBatchParams {
-  shouldStartAtBatch: number // 5 bytes -- starts at batch
+export interface SequencerTransactionBatch {
+  shouldStartAtElement: number // 5 bytes -- starts at batch
   totalElementsToAppend: number // 3 bytes -- total_elements_to_append
   contexts: BatchContext[] // total_elements[fixed_size[]]
   transactions: string[] // total_size_bytes[],total_size_bytes[]
@@ -24,7 +24,7 @@ export interface AppendSequencerBatchParams {
  */
 export class CanonicalTransactionChainContract extends Contract {
   public async appendSequencerBatch(
-    batch: AppendSequencerBatchParams
+    batch: SequencerTransactionBatch
   ): Promise<TransactionResponse> {
     return appendSequencerBatch(this, batch)
   }
@@ -38,7 +38,7 @@ const APPEND_SEQUENCER_BATCH_METHOD_ID = 'appendSequencerBatch()'
 
 const appendSequencerBatch = async (
   OVM_CanonicalTransactionChain: Contract,
-  batch: AppendSequencerBatchParams
+  batch: SequencerTransactionBatch
 ): Promise<TransactionResponse> => {
   const methodId = keccak256(
     Buffer.from(APPEND_SEQUENCER_BATCH_METHOD_ID)
@@ -51,9 +51,9 @@ const appendSequencerBatch = async (
 }
 
 export const encodeAppendSequencerBatch = (
-  b: AppendSequencerBatchParams
+  b: SequencerTransactionBatch
 ): string => {
-  const encodedShouldStartAtBatch = encodeHex(b.shouldStartAtBatch, 10)
+  const encodedShouldStartAtElement = encodeHex(b.shouldStartAtElement, 10)
   const encodedTotalElementsToAppend = encodeHex(b.totalElementsToAppend, 6)
 
   const encodedContextsHeader = encodeHex(b.contexts.length, 6)
@@ -71,7 +71,7 @@ export const encodeAppendSequencerBatch = (
     return acc + encodedTxDataHeader + remove0x(cur)
   }, '')
   return (
-    encodedShouldStartAtBatch +
+    encodedShouldStartAtElement +
     encodedTotalElementsToAppend +
     encodedContexts +
     encodedTransactionData


### PR DESCRIPTION
There were a few terribly named variables that have been left around because the batch submitter doesn't get a lot of love. 

Just updating these names for a little added sanity -- there's a bunch more refactoring needed but this at least goes in the right direction towards a sane batch submitter. 