### PR TITLE
Fix error in getReceiptWithResubmission

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.11.3",
     "@types/sinon-chai": "^3.2.4",
+    "@types/bluebird": "^3.5.20",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "ethereum-waffle": "3.0.0",

--- a/src/batch-submitter/batch-submitter.ts
+++ b/src/batch-submitter/batch-submitter.ts
@@ -158,7 +158,7 @@ export abstract class BatchSubmitter {
     const promises = [...receiptPromises, sleepAndReturnResubmit(
       resubmissionTimeout
     )]
-    const val = await bPromise.any(promises)
+    const val = await bPromise.any(Promise.resolve(promises))
 
     if (val === 'resubmit') {
       log.debug(`Tx resubmission timeout reached for hash: ${response.hash}; nonce: ${response.nonce}.
@@ -181,7 +181,7 @@ export abstract class BatchSubmitter {
         log
       )
     } else {
-      return val
+      return <TransactionReceipt>val
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,6 +823,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/bluebird@^3.5.20":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.33.tgz#d79c020f283bd50bd76101d7d300313c107325fc"
+  integrity sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==
+
 "@types/bn.js@*", "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.5":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"


### PR DESCRIPTION
Fix wrong argument passed to the bluebird `Promise.any` method.

This prevented the state submitter to correctly wait for the receipt of the state update