### PR TITLE
[Feat] Autopublish new versions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,24 +1,45 @@
-name: Create Releases on Tags
+name: Auto tag-release-publish
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - master
 
 jobs:
-  release:
+  tag:
+    name: Create tag for new version
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.create_new_tag.outputs.tag }}
     steps:
-      - name: Create GitHub release
-        uses: Roang-zero1/github-create-release-action@master
+      - uses: actions/checkout@v2
         with:
-          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+          fetch-depth: 2
+      - uses: salsify/action-detect-and-tag-new-version@v2
+        id: create_new_tag
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.tag_name
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/create-release@v1
+        id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.tag.outputs.tag_name }}
+          release_name: ${{ needs.tag.outputs.tag_name }}
+          draft: false
+          prerelease: false
 
   docker:
     name: Build & Push to DockerHub
     runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.tag_name
 
     steps:
       - uses: actions/checkout@v2
@@ -26,16 +47,12 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }} | docker login -u ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME}} --password-stdin
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-
       - name: Build and push Optimistic Ethereum Node image to DockerHub
         run: |
           git clone https://github.com/ethereum-optimism/docker.git \
               $HOME/docker
           cd $HOME/docker
-          ./build.sh -s batch-submitter -b ${{ steps.get_version.outputs.VERSION }}
-          docker push ethereumoptimism/batch-submitter:${{ steps.get_version.outputs.VERSION }}
+          ./build.sh -s batch-submitter -b ${{ needs.tag.outputs.tag_name }}
+          docker push ethereumoptimism/batch-submitter:${{ needs.tag.outputs.tag_name }}
       - name: Logout of DockerHub
         run: docker logout


### PR DESCRIPTION
This change enables autopublishing from updating the version in `package.json`.

same concern as data-transport-layer: https://github.com/ethereum-optimism/data-transport-layer/pull/68