### PR TITLE
[Fix] Log true block number instead of range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/batch-submitter",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "[Optimism] Batch submission for sequencer & aggregators",
   "main": "build/index.js",
   "files": [

--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -271,7 +271,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     let batch: Batch = await bPromise.map(
       [...Array(blockRange).keys()],
       (i) => {
-        this.log.debug('Fetching L2BatchElement', { blockNo: i })
+        this.log.debug('Fetching L2BatchElement', { blockNo: startBlock + i })
         return this._getL2BatchElement(startBlock + i)
       },
       { concurrency: 50 }


### PR DESCRIPTION
Fix bug that's logging on our relative block # instead of actual. Yay!