### PR TITLE
Fix fixMonotonicity queueIndex bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc -p .",
     "clean": "rimraf build/",
     "lint": "tslint --format stylish --project .",
-    "test": "buidler test --show-stack-traces"
+    "test": "buidler test --show-stack-traces",
+    "fix": "prettier --config prettier-config.json --write \"{src,exec,test}/**/*.ts\""
   },
   "keywords": [
     "optimism",

--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -428,7 +428,10 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       // updateLatestTimestampAndBlockNumber is a helper which updates
       // the latest timestamp and block number based on the pending queue elements.
       const updateLatestTimestampAndBlockNumber = async () => {
-        if ((await this.chainContract.getNumPendingQueueElements()) !== 0) {
+        const pendingQueueElements = await this.chainContract.getNumPendingQueueElements()
+        const nextRemoteQueueElements = await this.chainContract.getNextQueueIndex()
+        const totalQueueElements = pendingQueueElements + nextRemoteQueueElements
+        if (nextQueueIndex < totalQueueElements) {
           const [
             queueEleHash,
             queueTimestamp,

--- a/src/batch-submitter/tx-batch-submitter.ts
+++ b/src/batch-submitter/tx-batch-submitter.ts
@@ -430,7 +430,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       const updateLatestTimestampAndBlockNumber = async () => {
         const pendingQueueElements = await this.chainContract.getNumPendingQueueElements()
         const nextRemoteQueueElements = await this.chainContract.getNextQueueIndex()
-        const totalQueueElements = pendingQueueElements + nextRemoteQueueElements
+        const totalQueueElements =
+          pendingQueueElements + nextRemoteQueueElements
         if (nextQueueIndex < totalQueueElements) {
           const [
             queueEleHash,


### PR DESCRIPTION
Fix a bug discovered in Kovan where we are attempting to query a queue index which does not exist. This happens when we fixMonotonicity and attempt increment the local `nextQueueIndex` too many times to a index that is greater than what is in the remote contracts